### PR TITLE
Avoid parse errors with potential svg attributes

### DIFF
--- a/lib/transform-html.js
+++ b/lib/transform-html.js
@@ -524,9 +524,9 @@ class HTMLTransformer {
         result.id = this.createVIdentifier(result, start + 1)
 
         for (const attr of attrs) {
-            const name = attr.name
+            const name = attr.prefix ? `${attr.prefix}:${attr.name}` : attr.name
             const value = attr.value
-            const attrLoc = attrLocs[name]
+            const attrLoc = attrLocs[name.toLowerCase()]
             const attribute =
                 this.createVAttribute(result, name, value, attrLoc)
 

--- a/test/fixtures/svg-attrs-camel-case.vue
+++ b/test/fixtures/svg-attrs-camel-case.vue
@@ -1,0 +1,9 @@
+<template>
+    <div>
+        <svg viewBox="0 0 40 40"></svg>
+    </div>
+</template>
+
+<script>
+module.exports = {}
+</script>

--- a/test/fixtures/svg-attrs-colon.vue
+++ b/test/fixtures/svg-attrs-colon.vue
@@ -1,0 +1,9 @@
+<template>
+    <svg>
+        <use xlink:href="#test"></use>
+    </svg>
+</template>
+
+<script>
+module.exports = {}
+</script>

--- a/test/index.js
+++ b/test/index.js
@@ -328,4 +328,32 @@ describe("Basic tests", () => {
             assert(actual === expected)
         })
     })
+
+    describe("About fixtures/svg-attrs.vue", () => {
+        it("parses attributes with colons", () => {
+            const cli = new CLIEngine({
+                cwd: FIXTURE_DIR,
+                envs: ["es6", "node"],
+                parser: PARSER_PATH,
+                useEslintrc: false,
+            })
+            const report = cli.executeOnFiles(["svg-attrs-colon.vue"])
+            const messages = report.results[0].messages
+
+            assert(messages.length === 0)
+        })
+
+        it("parses camelCased attributes", () => {
+            const cli = new CLIEngine({
+                cwd: FIXTURE_DIR,
+                envs: ["es6", "node"],
+                parser: PARSER_PATH,
+                useEslintrc: false,
+            })
+            const report = cli.executeOnFiles(["svg-attrs-camel-case.vue"])
+            const messages = report.results[0].messages
+
+            assert(messages.length === 0)
+        })
+    })
 })


### PR DESCRIPTION
Some svg attributes contain colons (e.g. `xlink:href`) or can be camelCased
(e.g. viewBox). This updates `createVStartTag` to handle these variations by
correctly finding their locations within the node hash.

Fixes #8.