### PR TITLE
In eslint 4.4.0 name of eslint property in context has changed to _linter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+*.ts eol=lf
 /test/fixtures/crlf.vue eol=crlf

--- a/src/parser-services.ts
+++ b/src/parser-services.ts
@@ -29,8 +29,11 @@ function ensureEmitter(context: any): EventEmitter {
         emitter = new EventEmitter()
         emitters.set(ast, emitter)
 
+        // In eslint 4.4.0 name of this property has changed
+        const linter = context._linter || context.eslint
+
         // Traverse
-        context.eslint.on("Program:exit", (node: ESLintProgram) => {
+        linter.on("Program:exit", (node: ESLintProgram) => {
             if (node.templateBody != null) {
                 const generator = new NodeEventGenerator(emitter as EventEmitter)
                 traverseNodes(node.templateBody, generator)


### PR DESCRIPTION
fixes #14, vuejs/eslint-plugin-vue#134
https://github.com/eslint/eslint/commit/b74514d51c0020371c3a94ae2a1ff677bd42ab0e#diff-fa79c1006638179cf4232bd250ee5fcdR165