### PR TITLE
Fix type annotations range

### DIFF
--- a/src/ast/nodes.ts
+++ b/src/ast/nodes.ts
@@ -24,6 +24,7 @@ export interface HasParent {
  */
 export type Node =
     | ESLintNode
+    | TypeAnnotation
     | VNode
     | VForExpression
     | VOnExpression
@@ -348,6 +349,7 @@ export type ESLintExpression =
 export interface ESLintIdentifier extends HasLocation, HasParent {
     type: "Identifier"
     name: string
+    typeAnnotation?: TypeAnnotation | null
 }
 
 export interface ESLintLiteral extends HasLocation, HasParent {
@@ -612,6 +614,13 @@ export interface ESLintLegacyRestProperty extends HasLocation, HasParent {
 export interface ESLintLegacySpreadProperty extends HasLocation, HasParent {
     type: "SpreadProperty" | "ExperimentalSpreadProperty"
     argument: ESLintExpression
+}
+
+/**
+ * Top-level type annotation from `typescript-eslint-parser` and `babel-eslint`
+ */
+export interface TypeAnnotation extends HasLocation, HasParent {
+    type: "TSTypeAnnotation" | "TypeAnnotation"
 }
 
 //------------------------------------------------------------------------------

--- a/src/script/index.ts
+++ b/src/script/index.ts
@@ -82,6 +82,15 @@ function postprocess(
                     traversed.add(node.range)
                     locationCalculator.fixLocation(node)
                 }
+
+                if (
+                    node.type === "Identifier" &&
+                    node.typeAnnotation &&
+                    !traversed.has(node.typeAnnotation)
+                ) {
+                    traversed.add(node.typeAnnotation)
+                    locationCalculator.fixLocation(node.typeAnnotation)
+                }
             }
         },
 

--- a/test/fixtures/location-issue-type-annotation.vue
+++ b/test/fixtures/location-issue-type-annotation.vue
@@ -1,0 +1,24 @@
+<template>
+  <div>{{ msg }}</div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+enum Direction {
+  Up,
+  Down,
+}
+
+const baz : string = 'hi'; // <- wrong range of type annotation
+
+export default Vue.extend({
+  name: 'HelloWorld',
+  props: {
+    msg: String,
+  },
+});
+</script>
+
+<style>
+</style>

--- a/test/index.js
+++ b/test/index.js
@@ -396,6 +396,31 @@ describe("Basic tests", () => {
         })
     })
 
+    describe("About fixtures/location-issue-type-annotation.vue", () => {
+        it("typeAnnotation node in Identifier should have correct location.", () => {
+            const cli = new CLIEngine({
+                cwd: FIXTURE_DIR,
+                envs: ["browser", "node"],
+                parser: PARSER_PATH,
+                parserOptions: {
+                    parser: "typescript-eslint-parser",
+                    sourceType: "module",
+                    ecmaVersion: 2017,
+                },
+                rules: {
+                    "space-infix-ops": "error",
+                },
+                useEslintrc: false,
+            })
+            const report = cli.executeOnFiles([
+                "location-issue-type-annotation.vue",
+            ])
+            const messages = report.results[0].messages
+
+            assert(messages.length === 0)
+        })
+    })
+
     describe("About unexpected-null-character errors", () => {
         it("should keep NULL in DATA state.", () => {
             const ast = parse("<template>\u0000</template>")


### PR DESCRIPTION
This PR fixes ranges in `typeAnnotation` nodes.

Full discussion and description of the problem can be found here: https://github.com/vuejs/vue-cli/issues/1672#issuecomment-412293947

Essentially, because of not updated range of typeAnnotation - the rule `space-infix-ops` reported wrong nodes causing confusion among typescript users.