### PR TITLE
Add `getDocumentFragment()` to parserServices

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ This is useful for people who use the language ESLint community doesn't provide 
 - This parser provides `parserServices` to traverse `<template>`.
     - `defineTemplateBodyVisitor(templateVisitor, scriptVisitor)` ... returns ESLint visitor to traverse `<template>`.
     - `getTemplateBodyTokenStore()` ... returns ESLint `TokenStore` to get the tokens of `<template>`.
+    - `getDocumentFragment()` ... returns the root `VDocumentFragment`.
 - [ast.md](./docs/ast.md) is `<template>` AST specification.
 - [mustache-interpolation-spacing.js](https://github.com/vuejs/eslint-plugin-vue/blob/b434ff99d37f35570fa351681e43ba2cf5746db3/lib/rules/mustache-interpolation-spacing.js) is an example.
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "pretest": "run-s build lint",
     "test": "nyc npm run _mocha",
     "preupdate-fixtures": "npm run -s build",
-    "update-fixtures": "node scripts/update-fixtures-ast.js",
+    "update-fixtures": "node scripts/update-fixtures-ast.js && node scripts/update-fixtures-document-fragment.js",
     "preversion": "npm test",
     "version": "npm run -s build",
     "postversion": "git push && git push --tags",

--- a/scripts/update-fixtures-document-fragment.js
+++ b/scripts/update-fixtures-document-fragment.js
@@ -1,0 +1,68 @@
+"use strict"
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const fs = require("fs")
+const path = require("path")
+const parser = require("../")
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const ROOT = path.join(__dirname, "../test/fixtures/document-fragment")
+const TARGETS = fs.readdirSync(ROOT)
+const PARSER_OPTIONS = {
+    comment: true,
+    ecmaVersion: 6,
+    loc: true,
+    range: true,
+    tokens: true,
+    sourceType: "module",
+}
+
+/**
+ * Remove `parent` proeprties from the given AST.
+ * @param {string} key The key.
+ * @param {any} value The value of the key.
+ * @returns {any} The value of the key to output.
+ */
+function replacer(key, value) {
+    if (key === "parent") {
+        return undefined
+    }
+    if (key === "errors" && Array.isArray(value)) {
+        return value.map(e => ({
+            message: e.message,
+            index: e.index,
+            lineNumber: e.lineNumber,
+            column: e.column,
+        }))
+    }
+    return value
+}
+
+//------------------------------------------------------------------------------
+// Main
+//------------------------------------------------------------------------------
+
+for (const name of TARGETS) {
+    const sourceFileName = fs
+        .readdirSync(path.join(ROOT, name))
+        .find(f => f.startsWith("source."))
+    const sourcePath = path.join(ROOT, `${name}/${sourceFileName}`)
+    const source = fs.readFileSync(sourcePath, "utf8")
+    const result = parser.parseForESLint(
+        source,
+        Object.assign({ filePath: sourcePath }, PARSER_OPTIONS)
+    )
+    const actual = result.services.getDocumentFragment()
+
+    const resultPath = path.join(ROOT, `${name}/document-fragment.json`)
+
+    console.log("Update:", name)
+
+    fs.writeFileSync(resultPath, JSON.stringify(actual, replacer, 4))
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,8 +90,10 @@ export function parseForESLint(
     )
 
     let result: AST.ESLintExtendedProgram
+    let document: AST.VDocumentFragment | null
     if (!isVueFile(code, options)) {
         result = parseScript(code, options)
+        document = null
     } else {
         const skipParsingScript = options.parser === false
         const tokenizer = new HTMLTokenizer(code)
@@ -120,11 +122,12 @@ export function parseForESLint(
         }
 
         result.ast.templateBody = templateBody
+        document = rootAST
     }
 
     result.services = Object.assign(
         result.services || {},
-        services.define(result.ast),
+        services.define(result.ast, document),
     )
 
     return result

--- a/src/parser-services.ts
+++ b/src/parser-services.ts
@@ -6,7 +6,12 @@
 import EventEmitter from "events"
 import NodeEventGenerator from "./external/node-event-generator"
 import TokenStore from "./external/token-store"
-import { traverseNodes, ESLintProgram, VElement } from "./ast"
+import {
+    traverseNodes,
+    ESLintProgram,
+    VElement,
+    VDocumentFragment,
+} from "./ast"
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -35,13 +40,22 @@ export interface ParserServices {
      * @returns The token store of template body.
      */
     getTemplateBodyTokenStore(): TokenStore
+
+    /**
+     * Get the root document fragment.
+     * @returns The root document fragment.
+     */
+    getDocumentFragment(): VDocumentFragment | null
 }
 
 /**
  * Define the parser service
  * @param rootAST
  */
-export function define(rootAST: ESLintProgram): ParserServices {
+export function define(
+    rootAST: ESLintProgram,
+    document: VDocumentFragment | null,
+): ParserServices {
     return {
         /**
          * Define handlers to traverse the template body.
@@ -114,6 +128,14 @@ export function define(rootAST: ESLintProgram): ParserServices {
             }
 
             return store
+        },
+
+        /**
+         * Get the root document fragment.
+         * @returns The root document fragment.
+         */
+        getDocumentFragment(): VDocumentFragment | null {
+            return document
         },
     }
 }

--- a/test/document-fragment.js
+++ b/test/document-fragment.js
@@ -1,0 +1,80 @@
+"use strict"
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const assert = require("assert")
+const fs = require("fs")
+const path = require("path")
+const parser = require("..")
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const ROOT = path.join(__dirname, "fixtures/document-fragment")
+const TARGETS = fs.readdirSync(ROOT)
+const PARSER_OPTIONS = {
+    comment: true,
+    ecmaVersion: 6,
+    loc: true,
+    range: true,
+    tokens: true,
+    sourceType: "module",
+}
+
+/**
+ * Remove `parent` proeprties from the given AST.
+ * @param {string} key The key.
+ * @param {any} value The value of the key.
+ * @returns {any} The value of the key to output.
+ */
+function replacer(key, value) {
+    if (key === "parent") {
+        return undefined
+    }
+    if (key === "errors" && Array.isArray(value)) {
+        return value.map(e => ({
+            message: e.message,
+            index: e.index,
+            lineNumber: e.lineNumber,
+            column: e.column,
+        }))
+    }
+    return value
+}
+
+//------------------------------------------------------------------------------
+// Main
+//------------------------------------------------------------------------------
+
+describe("services.getDocumentFragment", () => {
+    for (const name of TARGETS) {
+        const sourceFileName = fs
+            .readdirSync(path.join(ROOT, name))
+            .find(f => f.startsWith("source."))
+        const sourcePath = path.join(ROOT, `${name}/${sourceFileName}`)
+        const source = fs.readFileSync(sourcePath, "utf8")
+        const result = parser.parseForESLint(
+            source,
+            Object.assign({ filePath: sourcePath }, PARSER_OPTIONS)
+        )
+        const actual = result.services.getDocumentFragment()
+
+        describe(`'test/fixtures/document-fragment/${name}/${sourceFileName}'`, () => {
+            it("should be parsed to valid document fragment.", () => {
+                const resultPath = path.join(
+                    ROOT,
+                    `${name}/document-fragment.json`
+                )
+                const expected = fs.readFileSync(resultPath, "utf8")
+
+                assert.strictEqual(
+                    JSON.stringify(actual, replacer, 4),
+                    expected
+                )
+            })
+        })
+    }
+})

--- a/test/fixtures/document-fragment/html-file/document-fragment.json
+++ b/test/fixtures/document-fragment/html-file/document-fragment.json
@@ -1,0 +1,2223 @@
+{
+    "type": "VDocumentFragment",
+    "range": [
+        0,
+        338
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 21,
+            "column": 7
+        }
+    },
+    "children": [
+        {
+            "type": "VText",
+            "range": [
+                15,
+                16
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 15
+                },
+                "end": {
+                    "line": 2,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "VElement",
+            "range": [
+                16,
+                338
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 0
+                },
+                "end": {
+                    "line": 21,
+                    "column": 7
+                }
+            },
+            "name": "html",
+            "rawName": "html",
+            "namespace": "http://www.w3.org/1999/xhtml",
+            "startTag": {
+                "type": "VStartTag",
+                "range": [
+                    16,
+                    22
+                ],
+                "loc": {
+                    "start": {
+                        "line": 2,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 2,
+                        "column": 6
+                    }
+                },
+                "selfClosing": false,
+                "attributes": []
+            },
+            "children": [
+                {
+                    "type": "VText",
+                    "range": [
+                        22,
+                        23
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 2,
+                            "column": 6
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 0
+                        }
+                    },
+                    "value": "\n"
+                },
+                {
+                    "type": "VElement",
+                    "range": [
+                        23,
+                        101
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 9,
+                            "column": 7
+                        }
+                    },
+                    "name": "head",
+                    "rawName": "head",
+                    "namespace": "http://www.w3.org/1999/xhtml",
+                    "startTag": {
+                        "type": "VStartTag",
+                        "range": [
+                            23,
+                            29
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 3,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 6
+                            }
+                        },
+                        "selfClosing": false,
+                        "attributes": []
+                    },
+                    "children": [
+                        {
+                            "type": "VText",
+                            "range": [
+                                29,
+                                32
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 6
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 2
+                                }
+                            },
+                            "value": "\n  "
+                        },
+                        {
+                            "type": "VElement",
+                            "range": [
+                                32,
+                                93
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 2
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 10
+                                }
+                            },
+                            "name": "style",
+                            "rawName": "style",
+                            "namespace": "http://www.w3.org/1999/xhtml",
+                            "startTag": {
+                                "type": "VStartTag",
+                                "range": [
+                                    32,
+                                    55
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 4,
+                                        "column": 2
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 25
+                                    }
+                                },
+                                "selfClosing": false,
+                                "attributes": [
+                                    {
+                                        "type": "VAttribute",
+                                        "range": [
+                                            39,
+                                            54
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 4,
+                                                "column": 9
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 24
+                                            }
+                                        },
+                                        "directive": false,
+                                        "key": {
+                                            "type": "VIdentifier",
+                                            "range": [
+                                                39,
+                                                43
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 4,
+                                                    "column": 9
+                                                },
+                                                "end": {
+                                                    "line": 4,
+                                                    "column": 13
+                                                }
+                                            },
+                                            "name": "type",
+                                            "rawName": "type"
+                                        },
+                                        "value": {
+                                            "type": "VLiteral",
+                                            "range": [
+                                                44,
+                                                54
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 4,
+                                                    "column": 14
+                                                },
+                                                "end": {
+                                                    "line": 4,
+                                                    "column": 24
+                                                }
+                                            },
+                                            "value": "text/css"
+                                        }
+                                    }
+                                ]
+                            },
+                            "children": [
+                                {
+                                    "type": "VText",
+                                    "range": [
+                                        55,
+                                        85
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 4,
+                                            "column": 25
+                                        },
+                                        "end": {
+                                            "line": 8,
+                                            "column": 2
+                                        }
+                                    },
+                                    "value": "\n  a {\n    color: pink;\n  }\n  "
+                                }
+                            ],
+                            "endTag": {
+                                "type": "VEndTag",
+                                "range": [
+                                    85,
+                                    93
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 8,
+                                        "column": 2
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 10
+                                    }
+                                }
+                            },
+                            "variables": []
+                        },
+                        {
+                            "type": "VText",
+                            "range": [
+                                93,
+                                94
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 8,
+                                    "column": 10
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 0
+                                }
+                            },
+                            "value": "\n"
+                        }
+                    ],
+                    "endTag": {
+                        "type": "VEndTag",
+                        "range": [
+                            94,
+                            101
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 9,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 7
+                            }
+                        }
+                    },
+                    "variables": []
+                },
+                {
+                    "type": "VText",
+                    "range": [
+                        101,
+                        102
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 9,
+                            "column": 7
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 0
+                        }
+                    },
+                    "value": "\n"
+                },
+                {
+                    "type": "VElement",
+                    "range": [
+                        102,
+                        330
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 10,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 20,
+                            "column": 7
+                        }
+                    },
+                    "name": "body",
+                    "rawName": "body",
+                    "namespace": "http://www.w3.org/1999/xhtml",
+                    "startTag": {
+                        "type": "VStartTag",
+                        "range": [
+                            102,
+                            108
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 10,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 10,
+                                "column": 6
+                            }
+                        },
+                        "selfClosing": false,
+                        "attributes": []
+                    },
+                    "children": [
+                        {
+                            "type": "VText",
+                            "range": [
+                                108,
+                                111
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 10,
+                                    "column": 6
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "column": 2
+                                }
+                            },
+                            "value": "\n  "
+                        },
+                        {
+                            "type": "VElement",
+                            "range": [
+                                111,
+                                122
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 11,
+                                    "column": 2
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "column": 13
+                                }
+                            },
+                            "name": "div",
+                            "rawName": "div",
+                            "namespace": "http://www.w3.org/1999/xhtml",
+                            "startTag": {
+                                "type": "VStartTag",
+                                "range": [
+                                    111,
+                                    116
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 11,
+                                        "column": 2
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 7
+                                    }
+                                },
+                                "selfClosing": false,
+                                "attributes": []
+                            },
+                            "children": [],
+                            "endTag": {
+                                "type": "VEndTag",
+                                "range": [
+                                    116,
+                                    122
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 11,
+                                        "column": 7
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 13
+                                    }
+                                }
+                            },
+                            "variables": []
+                        },
+                        {
+                            "type": "VText",
+                            "range": [
+                                122,
+                                125
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 11,
+                                    "column": 13
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 2
+                                }
+                            },
+                            "value": "\n  "
+                        },
+                        {
+                            "type": "VElement",
+                            "range": [
+                                125,
+                                223
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 12,
+                                    "column": 2
+                                },
+                                "end": {
+                                    "line": 14,
+                                    "column": 11
+                                }
+                            },
+                            "name": "script",
+                            "rawName": "script",
+                            "namespace": "http://www.w3.org/1999/xhtml",
+                            "startTag": {
+                                "type": "VStartTag",
+                                "range": [
+                                    125,
+                                    182
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 12,
+                                        "column": 2
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 59
+                                    }
+                                },
+                                "selfClosing": false,
+                                "attributes": [
+                                    {
+                                        "type": "VAttribute",
+                                        "range": [
+                                            133,
+                                            155
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 12,
+                                                "column": 10
+                                            },
+                                            "end": {
+                                                "line": 12,
+                                                "column": 32
+                                            }
+                                        },
+                                        "directive": false,
+                                        "key": {
+                                            "type": "VIdentifier",
+                                            "range": [
+                                                133,
+                                                137
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 12,
+                                                    "column": 10
+                                                },
+                                                "end": {
+                                                    "line": 12,
+                                                    "column": 14
+                                                }
+                                            },
+                                            "name": "type",
+                                            "rawName": "type"
+                                        },
+                                        "value": {
+                                            "type": "VLiteral",
+                                            "range": [
+                                                138,
+                                                155
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 12,
+                                                    "column": 15
+                                                },
+                                                "end": {
+                                                    "line": 12,
+                                                    "column": 32
+                                                }
+                                            },
+                                            "value": "text/x-template"
+                                        }
+                                    },
+                                    {
+                                        "type": "VAttribute",
+                                        "range": [
+                                            156,
+                                            181
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 12,
+                                                "column": 33
+                                            },
+                                            "end": {
+                                                "line": 12,
+                                                "column": 58
+                                            }
+                                        },
+                                        "directive": false,
+                                        "key": {
+                                            "type": "VIdentifier",
+                                            "range": [
+                                                156,
+                                                158
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 12,
+                                                    "column": 33
+                                                },
+                                                "end": {
+                                                    "line": 12,
+                                                    "column": 35
+                                                }
+                                            },
+                                            "name": "id",
+                                            "rawName": "id"
+                                        },
+                                        "value": {
+                                            "type": "VLiteral",
+                                            "range": [
+                                                159,
+                                                181
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 12,
+                                                    "column": 36
+                                                },
+                                                "end": {
+                                                    "line": 12,
+                                                    "column": 58
+                                                }
+                                            },
+                                            "value": "hello-world-template"
+                                        }
+                                    }
+                                ]
+                            },
+                            "children": [
+                                {
+                                    "type": "VText",
+                                    "range": [
+                                        182,
+                                        214
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 12,
+                                            "column": 59
+                                        },
+                                        "end": {
+                                            "line": 14,
+                                            "column": 2
+                                        }
+                                    },
+                                    "value": "\n    <p>Hello hello hello</p>\n  "
+                                }
+                            ],
+                            "endTag": {
+                                "type": "VEndTag",
+                                "range": [
+                                    214,
+                                    223
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 14,
+                                        "column": 2
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 11
+                                    }
+                                }
+                            },
+                            "variables": []
+                        },
+                        {
+                            "type": "VText",
+                            "range": [
+                                223,
+                                226
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 14,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 15,
+                                    "column": 2
+                                }
+                            },
+                            "value": "\n  "
+                        },
+                        {
+                            "type": "VElement",
+                            "range": [
+                                226,
+                                322
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 15,
+                                    "column": 2
+                                },
+                                "end": {
+                                    "line": 19,
+                                    "column": 11
+                                }
+                            },
+                            "name": "script",
+                            "rawName": "script",
+                            "namespace": "http://www.w3.org/1999/xhtml",
+                            "startTag": {
+                                "type": "VStartTag",
+                                "range": [
+                                    226,
+                                    234
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 15,
+                                        "column": 2
+                                    },
+                                    "end": {
+                                        "line": 15,
+                                        "column": 10
+                                    }
+                                },
+                                "selfClosing": false,
+                                "attributes": []
+                            },
+                            "children": [
+                                {
+                                    "type": "VText",
+                                    "range": [
+                                        234,
+                                        313
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 15,
+                                            "column": 10
+                                        },
+                                        "end": {
+                                            "line": 19,
+                                            "column": 2
+                                        }
+                                    },
+                                    "value": "\n  Vue.component('hello-world', {\n    template: '#hello-world-template'\n  })\n  "
+                                }
+                            ],
+                            "endTag": {
+                                "type": "VEndTag",
+                                "range": [
+                                    313,
+                                    322
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 19,
+                                        "column": 2
+                                    },
+                                    "end": {
+                                        "line": 19,
+                                        "column": 11
+                                    }
+                                }
+                            },
+                            "variables": []
+                        },
+                        {
+                            "type": "VText",
+                            "range": [
+                                322,
+                                323
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 19,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 0
+                                }
+                            },
+                            "value": "\n"
+                        }
+                    ],
+                    "endTag": {
+                        "type": "VEndTag",
+                        "range": [
+                            323,
+                            330
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 20,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 20,
+                                "column": 7
+                            }
+                        }
+                    },
+                    "variables": []
+                },
+                {
+                    "type": "VText",
+                    "range": [
+                        330,
+                        331
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 20,
+                            "column": 7
+                        },
+                        "end": {
+                            "line": 21,
+                            "column": 0
+                        }
+                    },
+                    "value": "\n"
+                }
+            ],
+            "endTag": {
+                "type": "VEndTag",
+                "range": [
+                    331,
+                    338
+                ],
+                "loc": {
+                    "start": {
+                        "line": 21,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 21,
+                        "column": 7
+                    }
+                }
+            },
+            "variables": []
+        }
+    ],
+    "tokens": [
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                15,
+                16
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 15
+                },
+                "end": {
+                    "line": 2,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLTagOpen",
+            "range": [
+                16,
+                21
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 0
+                },
+                "end": {
+                    "line": 2,
+                    "column": 5
+                }
+            },
+            "value": "html"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                21,
+                22
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 5
+                },
+                "end": {
+                    "line": 2,
+                    "column": 6
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                22,
+                23
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 6
+                },
+                "end": {
+                    "line": 3,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLTagOpen",
+            "range": [
+                23,
+                28
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 5
+                }
+            },
+            "value": "head"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                28,
+                29
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 5
+                },
+                "end": {
+                    "line": 3,
+                    "column": 6
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                29,
+                32
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 6
+                },
+                "end": {
+                    "line": 4,
+                    "column": 2
+                }
+            },
+            "value": "\n  "
+        },
+        {
+            "type": "HTMLTagOpen",
+            "range": [
+                32,
+                38
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 2
+                },
+                "end": {
+                    "line": 4,
+                    "column": 8
+                }
+            },
+            "value": "style"
+        },
+        {
+            "type": "HTMLIdentifier",
+            "range": [
+                39,
+                43
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 9
+                },
+                "end": {
+                    "line": 4,
+                    "column": 13
+                }
+            },
+            "value": "type"
+        },
+        {
+            "type": "HTMLAssociation",
+            "range": [
+                43,
+                44
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 13
+                },
+                "end": {
+                    "line": 4,
+                    "column": 14
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLLiteral",
+            "range": [
+                44,
+                54
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 14
+                },
+                "end": {
+                    "line": 4,
+                    "column": 24
+                }
+            },
+            "value": "text/css"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                54,
+                55
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 24
+                },
+                "end": {
+                    "line": 4,
+                    "column": 25
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                55,
+                58
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 25
+                },
+                "end": {
+                    "line": 5,
+                    "column": 2
+                }
+            },
+            "value": "\n  "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                58,
+                59
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 2
+                },
+                "end": {
+                    "line": 5,
+                    "column": 3
+                }
+            },
+            "value": "a"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                59,
+                60
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 3
+                },
+                "end": {
+                    "line": 5,
+                    "column": 4
+                }
+            },
+            "value": " "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                60,
+                61
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 4
+                },
+                "end": {
+                    "line": 5,
+                    "column": 5
+                }
+            },
+            "value": "{"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                61,
+                66
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 5
+                },
+                "end": {
+                    "line": 6,
+                    "column": 4
+                }
+            },
+            "value": "\n    "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                66,
+                72
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 4
+                },
+                "end": {
+                    "line": 6,
+                    "column": 10
+                }
+            },
+            "value": "color:"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                72,
+                73
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 10
+                },
+                "end": {
+                    "line": 6,
+                    "column": 11
+                }
+            },
+            "value": " "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                73,
+                78
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 11
+                },
+                "end": {
+                    "line": 6,
+                    "column": 16
+                }
+            },
+            "value": "pink;"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                78,
+                81
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 16
+                },
+                "end": {
+                    "line": 7,
+                    "column": 2
+                }
+            },
+            "value": "\n  "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                81,
+                82
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 2
+                },
+                "end": {
+                    "line": 7,
+                    "column": 3
+                }
+            },
+            "value": "}"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                82,
+                85
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 3
+                },
+                "end": {
+                    "line": 8,
+                    "column": 2
+                }
+            },
+            "value": "\n  "
+        },
+        {
+            "type": "HTMLEndTagOpen",
+            "range": [
+                85,
+                92
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 2
+                },
+                "end": {
+                    "line": 8,
+                    "column": 9
+                }
+            },
+            "value": "style"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                92,
+                93
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 9
+                },
+                "end": {
+                    "line": 8,
+                    "column": 10
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                93,
+                94
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 10
+                },
+                "end": {
+                    "line": 9,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLEndTagOpen",
+            "range": [
+                94,
+                100
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 0
+                },
+                "end": {
+                    "line": 9,
+                    "column": 6
+                }
+            },
+            "value": "head"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                100,
+                101
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 6
+                },
+                "end": {
+                    "line": 9,
+                    "column": 7
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                101,
+                102
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 7
+                },
+                "end": {
+                    "line": 10,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLTagOpen",
+            "range": [
+                102,
+                107
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 0
+                },
+                "end": {
+                    "line": 10,
+                    "column": 5
+                }
+            },
+            "value": "body"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                107,
+                108
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 5
+                },
+                "end": {
+                    "line": 10,
+                    "column": 6
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                108,
+                111
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 6
+                },
+                "end": {
+                    "line": 11,
+                    "column": 2
+                }
+            },
+            "value": "\n  "
+        },
+        {
+            "type": "HTMLTagOpen",
+            "range": [
+                111,
+                115
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 2
+                },
+                "end": {
+                    "line": 11,
+                    "column": 6
+                }
+            },
+            "value": "div"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                115,
+                116
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 6
+                },
+                "end": {
+                    "line": 11,
+                    "column": 7
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLEndTagOpen",
+            "range": [
+                116,
+                121
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 7
+                },
+                "end": {
+                    "line": 11,
+                    "column": 12
+                }
+            },
+            "value": "div"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                121,
+                122
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 12
+                },
+                "end": {
+                    "line": 11,
+                    "column": 13
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                122,
+                125
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 13
+                },
+                "end": {
+                    "line": 12,
+                    "column": 2
+                }
+            },
+            "value": "\n  "
+        },
+        {
+            "type": "HTMLTagOpen",
+            "range": [
+                125,
+                132
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 2
+                },
+                "end": {
+                    "line": 12,
+                    "column": 9
+                }
+            },
+            "value": "script"
+        },
+        {
+            "type": "HTMLIdentifier",
+            "range": [
+                133,
+                137
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 10
+                },
+                "end": {
+                    "line": 12,
+                    "column": 14
+                }
+            },
+            "value": "type"
+        },
+        {
+            "type": "HTMLAssociation",
+            "range": [
+                137,
+                138
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 14
+                },
+                "end": {
+                    "line": 12,
+                    "column": 15
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLLiteral",
+            "range": [
+                138,
+                155
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 15
+                },
+                "end": {
+                    "line": 12,
+                    "column": 32
+                }
+            },
+            "value": "text/x-template"
+        },
+        {
+            "type": "HTMLIdentifier",
+            "range": [
+                156,
+                158
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 33
+                },
+                "end": {
+                    "line": 12,
+                    "column": 35
+                }
+            },
+            "value": "id"
+        },
+        {
+            "type": "HTMLAssociation",
+            "range": [
+                158,
+                159
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 35
+                },
+                "end": {
+                    "line": 12,
+                    "column": 36
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLLiteral",
+            "range": [
+                159,
+                181
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 36
+                },
+                "end": {
+                    "line": 12,
+                    "column": 58
+                }
+            },
+            "value": "hello-world-template"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                181,
+                182
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 58
+                },
+                "end": {
+                    "line": 12,
+                    "column": 59
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                182,
+                187
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 59
+                },
+                "end": {
+                    "line": 13,
+                    "column": 4
+                }
+            },
+            "value": "\n    "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                187,
+                195
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 4
+                },
+                "end": {
+                    "line": 13,
+                    "column": 12
+                }
+            },
+            "value": "<p>Hello"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                195,
+                196
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 12
+                },
+                "end": {
+                    "line": 13,
+                    "column": 13
+                }
+            },
+            "value": " "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                196,
+                201
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 13
+                },
+                "end": {
+                    "line": 13,
+                    "column": 18
+                }
+            },
+            "value": "hello"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                201,
+                202
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 18
+                },
+                "end": {
+                    "line": 13,
+                    "column": 19
+                }
+            },
+            "value": " "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                202,
+                211
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 19
+                },
+                "end": {
+                    "line": 13,
+                    "column": 28
+                }
+            },
+            "value": "hello</p>"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                211,
+                214
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 28
+                },
+                "end": {
+                    "line": 14,
+                    "column": 2
+                }
+            },
+            "value": "\n  "
+        },
+        {
+            "type": "HTMLEndTagOpen",
+            "range": [
+                214,
+                222
+            ],
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 2
+                },
+                "end": {
+                    "line": 14,
+                    "column": 10
+                }
+            },
+            "value": "script"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                222,
+                223
+            ],
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 10
+                },
+                "end": {
+                    "line": 14,
+                    "column": 11
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                223,
+                226
+            ],
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 11
+                },
+                "end": {
+                    "line": 15,
+                    "column": 2
+                }
+            },
+            "value": "\n  "
+        },
+        {
+            "type": "HTMLTagOpen",
+            "range": [
+                226,
+                233
+            ],
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 2
+                },
+                "end": {
+                    "line": 15,
+                    "column": 9
+                }
+            },
+            "value": "script"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                233,
+                234
+            ],
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 9
+                },
+                "end": {
+                    "line": 15,
+                    "column": 10
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                234,
+                237
+            ],
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 10
+                },
+                "end": {
+                    "line": 16,
+                    "column": 2
+                }
+            },
+            "value": "\n  "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                237,
+                265
+            ],
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 2
+                },
+                "end": {
+                    "line": 16,
+                    "column": 30
+                }
+            },
+            "value": "Vue.component('hello-world',"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                265,
+                266
+            ],
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 30
+                },
+                "end": {
+                    "line": 16,
+                    "column": 31
+                }
+            },
+            "value": " "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                266,
+                267
+            ],
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 31
+                },
+                "end": {
+                    "line": 16,
+                    "column": 32
+                }
+            },
+            "value": "{"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                267,
+                272
+            ],
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 32
+                },
+                "end": {
+                    "line": 17,
+                    "column": 4
+                }
+            },
+            "value": "\n    "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                272,
+                281
+            ],
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 4
+                },
+                "end": {
+                    "line": 17,
+                    "column": 13
+                }
+            },
+            "value": "template:"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                281,
+                282
+            ],
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 13
+                },
+                "end": {
+                    "line": 17,
+                    "column": 14
+                }
+            },
+            "value": " "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                282,
+                305
+            ],
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 14
+                },
+                "end": {
+                    "line": 17,
+                    "column": 37
+                }
+            },
+            "value": "'#hello-world-template'"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                305,
+                308
+            ],
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 37
+                },
+                "end": {
+                    "line": 18,
+                    "column": 2
+                }
+            },
+            "value": "\n  "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                308,
+                310
+            ],
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 2
+                },
+                "end": {
+                    "line": 18,
+                    "column": 4
+                }
+            },
+            "value": "})"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                310,
+                313
+            ],
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 4
+                },
+                "end": {
+                    "line": 19,
+                    "column": 2
+                }
+            },
+            "value": "\n  "
+        },
+        {
+            "type": "HTMLEndTagOpen",
+            "range": [
+                313,
+                321
+            ],
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 2
+                },
+                "end": {
+                    "line": 19,
+                    "column": 10
+                }
+            },
+            "value": "script"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                321,
+                322
+            ],
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 10
+                },
+                "end": {
+                    "line": 19,
+                    "column": 11
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                322,
+                323
+            ],
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 11
+                },
+                "end": {
+                    "line": 20,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLEndTagOpen",
+            "range": [
+                323,
+                329
+            ],
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 0
+                },
+                "end": {
+                    "line": 20,
+                    "column": 6
+                }
+            },
+            "value": "body"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                329,
+                330
+            ],
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 6
+                },
+                "end": {
+                    "line": 20,
+                    "column": 7
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                330,
+                331
+            ],
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 7
+                },
+                "end": {
+                    "line": 21,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLEndTagOpen",
+            "range": [
+                331,
+                337
+            ],
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 0
+                },
+                "end": {
+                    "line": 21,
+                    "column": 6
+                }
+            },
+            "value": "html"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                337,
+                338
+            ],
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 6
+                },
+                "end": {
+                    "line": 21,
+                    "column": 7
+                }
+            },
+            "value": ""
+        }
+    ],
+    "comments": [
+        {
+            "type": "HTMLBogusComment",
+            "range": [
+                0,
+                15
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            },
+            "value": "DOCTYPE html"
+        }
+    ],
+    "errors": []
+}

--- a/test/fixtures/document-fragment/html-file/source.html
+++ b/test/fixtures/document-fragment/html-file/source.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style type="text/css">
+  a {
+    color: pink;
+  }
+  </style>
+</head>
+<body>
+  <div></div>
+  <script type="text/x-template" id="hello-world-template">
+    <p>Hello hello hello</p>
+  </script>
+  <script>
+  Vue.component('hello-world', {
+    template: '#hello-world-template'
+  })
+  </script>
+</body>
+</html>

--- a/test/fixtures/document-fragment/template-tag-is-absent/document-fragment.json
+++ b/test/fixtures/document-fragment/template-tag-is-absent/document-fragment.json
@@ -1,0 +1,1954 @@
+{
+    "type": "VDocumentFragment",
+    "range": [
+        0,
+        133
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 13,
+            "column": 8
+        }
+    },
+    "children": [
+        {
+            "type": "VElement",
+            "range": [
+                0,
+                38
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 11
+                }
+            },
+            "name": "template",
+            "rawName": "template",
+            "namespace": "http://www.w3.org/1999/xhtml",
+            "startTag": {
+                "type": "VStartTag",
+                "range": [
+                    0,
+                    10
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 10
+                    }
+                },
+                "selfClosing": false,
+                "attributes": []
+            },
+            "children": [
+                {
+                    "type": "VText",
+                    "range": [
+                        10,
+                        15
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 10
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 4
+                        }
+                    },
+                    "value": "\n    "
+                },
+                {
+                    "type": "VElement",
+                    "range": [
+                        15,
+                        26
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 2,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 15
+                        }
+                    },
+                    "name": "div",
+                    "rawName": "div",
+                    "namespace": "http://www.w3.org/1999/xhtml",
+                    "startTag": {
+                        "type": "VStartTag",
+                        "range": [
+                            15,
+                            20
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 9
+                            }
+                        },
+                        "selfClosing": false,
+                        "attributes": []
+                    },
+                    "children": [],
+                    "endTag": {
+                        "type": "VEndTag",
+                        "range": [
+                            20,
+                            26
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 9
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 15
+                            }
+                        }
+                    },
+                    "variables": []
+                },
+                {
+                    "type": "VText",
+                    "range": [
+                        26,
+                        27
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 2,
+                            "column": 15
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 0
+                        }
+                    },
+                    "value": "\n"
+                }
+            ],
+            "endTag": {
+                "type": "VEndTag",
+                "range": [
+                    27,
+                    38
+                ],
+                "loc": {
+                    "start": {
+                        "line": 3,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 11
+                    }
+                }
+            },
+            "variables": [],
+            "tokens": [
+                {
+                    "type": "HTMLTagOpen",
+                    "range": [
+                        0,
+                        9
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 9
+                        }
+                    },
+                    "value": "template"
+                },
+                {
+                    "type": "HTMLTagClose",
+                    "range": [
+                        9,
+                        10
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 10
+                        }
+                    },
+                    "value": ""
+                },
+                {
+                    "type": "HTMLWhitespace",
+                    "range": [
+                        10,
+                        15
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 10
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 4
+                        }
+                    },
+                    "value": "\n    "
+                },
+                {
+                    "type": "HTMLTagOpen",
+                    "range": [
+                        15,
+                        19
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 2,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 8
+                        }
+                    },
+                    "value": "div"
+                },
+                {
+                    "type": "HTMLTagClose",
+                    "range": [
+                        19,
+                        20
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 2,
+                            "column": 8
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 9
+                        }
+                    },
+                    "value": ""
+                },
+                {
+                    "type": "HTMLEndTagOpen",
+                    "range": [
+                        20,
+                        25
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 2,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 14
+                        }
+                    },
+                    "value": "div"
+                },
+                {
+                    "type": "HTMLTagClose",
+                    "range": [
+                        25,
+                        26
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 2,
+                            "column": 14
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 15
+                        }
+                    },
+                    "value": ""
+                },
+                {
+                    "type": "HTMLWhitespace",
+                    "range": [
+                        26,
+                        27
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 2,
+                            "column": 15
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 0
+                        }
+                    },
+                    "value": "\n"
+                },
+                {
+                    "type": "HTMLEndTagOpen",
+                    "range": [
+                        27,
+                        37
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 10
+                        }
+                    },
+                    "value": "template"
+                },
+                {
+                    "type": "HTMLTagClose",
+                    "range": [
+                        37,
+                        38
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 10
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 11
+                        }
+                    },
+                    "value": ""
+                },
+                {
+                    "type": "HTMLWhitespace",
+                    "range": [
+                        38,
+                        39
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 11
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 0
+                        }
+                    },
+                    "value": "\n"
+                },
+                {
+                    "type": "HTMLTagOpen",
+                    "range": [
+                        39,
+                        46
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 4,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 7
+                        }
+                    },
+                    "value": "script"
+                },
+                {
+                    "type": "HTMLTagClose",
+                    "range": [
+                        46,
+                        47
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 4,
+                            "column": 7
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 8
+                        }
+                    },
+                    "value": ""
+                },
+                {
+                    "type": "HTMLWhitespace",
+                    "range": [
+                        47,
+                        48
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 4,
+                            "column": 8
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 0
+                        }
+                    },
+                    "value": "\n"
+                },
+                {
+                    "type": "HTMLRawText",
+                    "range": [
+                        48,
+                        54
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 6
+                        }
+                    },
+                    "value": "export"
+                },
+                {
+                    "type": "HTMLWhitespace",
+                    "range": [
+                        54,
+                        55
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 6
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 7
+                        }
+                    },
+                    "value": " "
+                },
+                {
+                    "type": "HTMLRawText",
+                    "range": [
+                        55,
+                        62
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 7
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 14
+                        }
+                    },
+                    "value": "default"
+                },
+                {
+                    "type": "HTMLWhitespace",
+                    "range": [
+                        62,
+                        63
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 14
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 15
+                        }
+                    },
+                    "value": " "
+                },
+                {
+                    "type": "HTMLRawText",
+                    "range": [
+                        63,
+                        64
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 15
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 16
+                        }
+                    },
+                    "value": "{"
+                },
+                {
+                    "type": "HTMLWhitespace",
+                    "range": [
+                        64,
+                        69
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 16
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 4
+                        }
+                    },
+                    "value": "\n    "
+                },
+                {
+                    "type": "HTMLRawText",
+                    "range": [
+                        69,
+                        74
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 6,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 9
+                        }
+                    },
+                    "value": "name:"
+                },
+                {
+                    "type": "HTMLWhitespace",
+                    "range": [
+                        74,
+                        75
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 6,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 10
+                        }
+                    },
+                    "value": " "
+                },
+                {
+                    "type": "HTMLRawText",
+                    "range": [
+                        75,
+                        81
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 6,
+                            "column": 10
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 16
+                        }
+                    },
+                    "value": "'test'"
+                },
+                {
+                    "type": "HTMLWhitespace",
+                    "range": [
+                        81,
+                        82
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 6,
+                            "column": 16
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 0
+                        }
+                    },
+                    "value": "\n"
+                },
+                {
+                    "type": "HTMLRawText",
+                    "range": [
+                        82,
+                        83
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 7,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 1
+                        }
+                    },
+                    "value": "}"
+                },
+                {
+                    "type": "HTMLWhitespace",
+                    "range": [
+                        83,
+                        84
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 7,
+                            "column": 1
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 0
+                        }
+                    },
+                    "value": "\n"
+                },
+                {
+                    "type": "HTMLEndTagOpen",
+                    "range": [
+                        84,
+                        92
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 8,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 8
+                        }
+                    },
+                    "value": "script"
+                },
+                {
+                    "type": "HTMLTagClose",
+                    "range": [
+                        92,
+                        93
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 8,
+                            "column": 8
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 9
+                        }
+                    },
+                    "value": ""
+                },
+                {
+                    "type": "HTMLWhitespace",
+                    "range": [
+                        93,
+                        94
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 8,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 9,
+                            "column": 0
+                        }
+                    },
+                    "value": "\n"
+                },
+                {
+                    "type": "HTMLTagOpen",
+                    "range": [
+                        94,
+                        100
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 9,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 9,
+                            "column": 6
+                        }
+                    },
+                    "value": "style"
+                },
+                {
+                    "type": "HTMLTagClose",
+                    "range": [
+                        100,
+                        101
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 9,
+                            "column": 6
+                        },
+                        "end": {
+                            "line": 9,
+                            "column": 7
+                        }
+                    },
+                    "value": ""
+                },
+                {
+                    "type": "HTMLWhitespace",
+                    "range": [
+                        101,
+                        102
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 9,
+                            "column": 7
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 0
+                        }
+                    },
+                    "value": "\n"
+                },
+                {
+                    "type": "HTMLRawText",
+                    "range": [
+                        102,
+                        103
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 10,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 1
+                        }
+                    },
+                    "value": "a"
+                },
+                {
+                    "type": "HTMLWhitespace",
+                    "range": [
+                        103,
+                        104
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 10,
+                            "column": 1
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 2
+                        }
+                    },
+                    "value": " "
+                },
+                {
+                    "type": "HTMLRawText",
+                    "range": [
+                        104,
+                        105
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 10,
+                            "column": 2
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 3
+                        }
+                    },
+                    "value": "{"
+                },
+                {
+                    "type": "HTMLWhitespace",
+                    "range": [
+                        105,
+                        110
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 10,
+                            "column": 3
+                        },
+                        "end": {
+                            "line": 11,
+                            "column": 4
+                        }
+                    },
+                    "value": "\n    "
+                },
+                {
+                    "type": "HTMLRawText",
+                    "range": [
+                        110,
+                        116
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 11,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 11,
+                            "column": 10
+                        }
+                    },
+                    "value": "color:"
+                },
+                {
+                    "type": "HTMLWhitespace",
+                    "range": [
+                        116,
+                        117
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 11,
+                            "column": 10
+                        },
+                        "end": {
+                            "line": 11,
+                            "column": 11
+                        }
+                    },
+                    "value": " "
+                },
+                {
+                    "type": "HTMLRawText",
+                    "range": [
+                        117,
+                        122
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 11,
+                            "column": 11
+                        },
+                        "end": {
+                            "line": 11,
+                            "column": 16
+                        }
+                    },
+                    "value": "pink;"
+                },
+                {
+                    "type": "HTMLWhitespace",
+                    "range": [
+                        122,
+                        123
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 11,
+                            "column": 16
+                        },
+                        "end": {
+                            "line": 12,
+                            "column": 0
+                        }
+                    },
+                    "value": "\n"
+                },
+                {
+                    "type": "HTMLRawText",
+                    "range": [
+                        123,
+                        124
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 12,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 12,
+                            "column": 1
+                        }
+                    },
+                    "value": "}"
+                },
+                {
+                    "type": "HTMLWhitespace",
+                    "range": [
+                        124,
+                        125
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 12,
+                            "column": 1
+                        },
+                        "end": {
+                            "line": 13,
+                            "column": 0
+                        }
+                    },
+                    "value": "\n"
+                },
+                {
+                    "type": "HTMLEndTagOpen",
+                    "range": [
+                        125,
+                        132
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 13,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 13,
+                            "column": 7
+                        }
+                    },
+                    "value": "style"
+                },
+                {
+                    "type": "HTMLTagClose",
+                    "range": [
+                        132,
+                        133
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 13,
+                            "column": 7
+                        },
+                        "end": {
+                            "line": 13,
+                            "column": 8
+                        }
+                    },
+                    "value": ""
+                }
+            ],
+            "comments": [],
+            "errors": []
+        },
+        {
+            "type": "VText",
+            "range": [
+                38,
+                39
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 11
+                },
+                "end": {
+                    "line": 4,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "VElement",
+            "range": [
+                39,
+                93
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 0
+                },
+                "end": {
+                    "line": 8,
+                    "column": 9
+                }
+            },
+            "name": "script",
+            "rawName": "script",
+            "namespace": "http://www.w3.org/1999/xhtml",
+            "startTag": {
+                "type": "VStartTag",
+                "range": [
+                    39,
+                    47
+                ],
+                "loc": {
+                    "start": {
+                        "line": 4,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 8
+                    }
+                },
+                "selfClosing": false,
+                "attributes": []
+            },
+            "children": [
+                {
+                    "type": "VText",
+                    "range": [
+                        47,
+                        84
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 4,
+                            "column": 8
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 0
+                        }
+                    },
+                    "value": "\nexport default {\n    name: 'test'\n}\n"
+                }
+            ],
+            "endTag": {
+                "type": "VEndTag",
+                "range": [
+                    84,
+                    93
+                ],
+                "loc": {
+                    "start": {
+                        "line": 8,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 8,
+                        "column": 9
+                    }
+                }
+            },
+            "variables": []
+        },
+        {
+            "type": "VText",
+            "range": [
+                93,
+                94
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 9
+                },
+                "end": {
+                    "line": 9,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "VElement",
+            "range": [
+                94,
+                133
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 0
+                },
+                "end": {
+                    "line": 13,
+                    "column": 8
+                }
+            },
+            "name": "style",
+            "rawName": "style",
+            "namespace": "http://www.w3.org/1999/xhtml",
+            "startTag": {
+                "type": "VStartTag",
+                "range": [
+                    94,
+                    101
+                ],
+                "loc": {
+                    "start": {
+                        "line": 9,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 9,
+                        "column": 7
+                    }
+                },
+                "selfClosing": false,
+                "attributes": []
+            },
+            "children": [
+                {
+                    "type": "VText",
+                    "range": [
+                        101,
+                        125
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 9,
+                            "column": 7
+                        },
+                        "end": {
+                            "line": 13,
+                            "column": 0
+                        }
+                    },
+                    "value": "\na {\n    color: pink;\n}\n"
+                }
+            ],
+            "endTag": {
+                "type": "VEndTag",
+                "range": [
+                    125,
+                    133
+                ],
+                "loc": {
+                    "start": {
+                        "line": 13,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 13,
+                        "column": 8
+                    }
+                }
+            },
+            "variables": []
+        }
+    ],
+    "tokens": [
+        {
+            "type": "HTMLTagOpen",
+            "range": [
+                0,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            },
+            "value": "template"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                9,
+                10
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 10
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                10,
+                15
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 2,
+                    "column": 4
+                }
+            },
+            "value": "\n    "
+        },
+        {
+            "type": "HTMLTagOpen",
+            "range": [
+                15,
+                19
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 8
+                }
+            },
+            "value": "div"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                19,
+                20
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 8
+                },
+                "end": {
+                    "line": 2,
+                    "column": 9
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLEndTagOpen",
+            "range": [
+                20,
+                25
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 9
+                },
+                "end": {
+                    "line": 2,
+                    "column": 14
+                }
+            },
+            "value": "div"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                25,
+                26
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 14
+                },
+                "end": {
+                    "line": 2,
+                    "column": 15
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                26,
+                27
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 15
+                },
+                "end": {
+                    "line": 3,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLEndTagOpen",
+            "range": [
+                27,
+                37
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 10
+                }
+            },
+            "value": "template"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                37,
+                38
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 10
+                },
+                "end": {
+                    "line": 3,
+                    "column": 11
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                38,
+                39
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 11
+                },
+                "end": {
+                    "line": 4,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLTagOpen",
+            "range": [
+                39,
+                46
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 0
+                },
+                "end": {
+                    "line": 4,
+                    "column": 7
+                }
+            },
+            "value": "script"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                46,
+                47
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 7
+                },
+                "end": {
+                    "line": 4,
+                    "column": 8
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                47,
+                48
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 8
+                },
+                "end": {
+                    "line": 5,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                48,
+                54
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 0
+                },
+                "end": {
+                    "line": 5,
+                    "column": 6
+                }
+            },
+            "value": "export"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                54,
+                55
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 6
+                },
+                "end": {
+                    "line": 5,
+                    "column": 7
+                }
+            },
+            "value": " "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                55,
+                62
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 7
+                },
+                "end": {
+                    "line": 5,
+                    "column": 14
+                }
+            },
+            "value": "default"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                62,
+                63
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 14
+                },
+                "end": {
+                    "line": 5,
+                    "column": 15
+                }
+            },
+            "value": " "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                63,
+                64
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 15
+                },
+                "end": {
+                    "line": 5,
+                    "column": 16
+                }
+            },
+            "value": "{"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                64,
+                69
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 16
+                },
+                "end": {
+                    "line": 6,
+                    "column": 4
+                }
+            },
+            "value": "\n    "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                69,
+                74
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 4
+                },
+                "end": {
+                    "line": 6,
+                    "column": 9
+                }
+            },
+            "value": "name:"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                74,
+                75
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 9
+                },
+                "end": {
+                    "line": 6,
+                    "column": 10
+                }
+            },
+            "value": " "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                75,
+                81
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 10
+                },
+                "end": {
+                    "line": 6,
+                    "column": 16
+                }
+            },
+            "value": "'test'"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                81,
+                82
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 16
+                },
+                "end": {
+                    "line": 7,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                82,
+                83
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 0
+                },
+                "end": {
+                    "line": 7,
+                    "column": 1
+                }
+            },
+            "value": "}"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                83,
+                84
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 1
+                },
+                "end": {
+                    "line": 8,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLEndTagOpen",
+            "range": [
+                84,
+                92
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 0
+                },
+                "end": {
+                    "line": 8,
+                    "column": 8
+                }
+            },
+            "value": "script"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                92,
+                93
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 8
+                },
+                "end": {
+                    "line": 8,
+                    "column": 9
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                93,
+                94
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 9
+                },
+                "end": {
+                    "line": 9,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLTagOpen",
+            "range": [
+                94,
+                100
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 0
+                },
+                "end": {
+                    "line": 9,
+                    "column": 6
+                }
+            },
+            "value": "style"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                100,
+                101
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 6
+                },
+                "end": {
+                    "line": 9,
+                    "column": 7
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                101,
+                102
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 7
+                },
+                "end": {
+                    "line": 10,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                102,
+                103
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 0
+                },
+                "end": {
+                    "line": 10,
+                    "column": 1
+                }
+            },
+            "value": "a"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                103,
+                104
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 1
+                },
+                "end": {
+                    "line": 10,
+                    "column": 2
+                }
+            },
+            "value": " "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                104,
+                105
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 2
+                },
+                "end": {
+                    "line": 10,
+                    "column": 3
+                }
+            },
+            "value": "{"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                105,
+                110
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 3
+                },
+                "end": {
+                    "line": 11,
+                    "column": 4
+                }
+            },
+            "value": "\n    "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                110,
+                116
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 4
+                },
+                "end": {
+                    "line": 11,
+                    "column": 10
+                }
+            },
+            "value": "color:"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                116,
+                117
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 10
+                },
+                "end": {
+                    "line": 11,
+                    "column": 11
+                }
+            },
+            "value": " "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                117,
+                122
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 11
+                },
+                "end": {
+                    "line": 11,
+                    "column": 16
+                }
+            },
+            "value": "pink;"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                122,
+                123
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 16
+                },
+                "end": {
+                    "line": 12,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                123,
+                124
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 0
+                },
+                "end": {
+                    "line": 12,
+                    "column": 1
+                }
+            },
+            "value": "}"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                124,
+                125
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 1
+                },
+                "end": {
+                    "line": 13,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLEndTagOpen",
+            "range": [
+                125,
+                132
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 0
+                },
+                "end": {
+                    "line": 13,
+                    "column": 7
+                }
+            },
+            "value": "style"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                132,
+                133
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 7
+                },
+                "end": {
+                    "line": 13,
+                    "column": 8
+                }
+            },
+            "value": ""
+        }
+    ],
+    "comments": [],
+    "errors": []
+}

--- a/test/fixtures/document-fragment/template-tag-is-absent/source.vue
+++ b/test/fixtures/document-fragment/template-tag-is-absent/source.vue
@@ -1,0 +1,13 @@
+<template>
+    <div></div>
+</template>
+<script>
+export default {
+    name: 'test'
+}
+</script>
+<style>
+a {
+    color: pink;
+}
+</style>

--- a/test/fixtures/document-fragment/template-tag-is-present/document-fragment.json
+++ b/test/fixtures/document-fragment/template-tag-is-present/document-fragment.json
@@ -1,0 +1,1028 @@
+{
+    "type": "VDocumentFragment",
+    "range": [
+        0,
+        117
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 13,
+            "column": 8
+        }
+    },
+    "children": [
+        {
+            "type": "VElement",
+            "range": [
+                0,
+                22
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 7
+                }
+            },
+            "name": "docs",
+            "rawName": "docs",
+            "namespace": "http://www.w3.org/1999/xhtml",
+            "startTag": {
+                "type": "VStartTag",
+                "range": [
+                    0,
+                    6
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 6
+                    }
+                },
+                "selfClosing": false,
+                "attributes": []
+            },
+            "children": [
+                {
+                    "type": "VText",
+                    "range": [
+                        6,
+                        15
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 6
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 0
+                        }
+                    },
+                    "value": "\n    doc\n"
+                }
+            ],
+            "endTag": {
+                "type": "VEndTag",
+                "range": [
+                    15,
+                    22
+                ],
+                "loc": {
+                    "start": {
+                        "line": 3,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 7
+                    }
+                }
+            },
+            "variables": []
+        },
+        {
+            "type": "VText",
+            "range": [
+                22,
+                23
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 7
+                },
+                "end": {
+                    "line": 4,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "VElement",
+            "range": [
+                23,
+                77
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 0
+                },
+                "end": {
+                    "line": 8,
+                    "column": 9
+                }
+            },
+            "name": "script",
+            "rawName": "script",
+            "namespace": "http://www.w3.org/1999/xhtml",
+            "startTag": {
+                "type": "VStartTag",
+                "range": [
+                    23,
+                    31
+                ],
+                "loc": {
+                    "start": {
+                        "line": 4,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 8
+                    }
+                },
+                "selfClosing": false,
+                "attributes": []
+            },
+            "children": [
+                {
+                    "type": "VText",
+                    "range": [
+                        31,
+                        68
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 4,
+                            "column": 8
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 0
+                        }
+                    },
+                    "value": "\nexport default {\n    name: 'test'\n}\n"
+                }
+            ],
+            "endTag": {
+                "type": "VEndTag",
+                "range": [
+                    68,
+                    77
+                ],
+                "loc": {
+                    "start": {
+                        "line": 8,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 8,
+                        "column": 9
+                    }
+                }
+            },
+            "variables": []
+        },
+        {
+            "type": "VText",
+            "range": [
+                77,
+                78
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 9
+                },
+                "end": {
+                    "line": 9,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "VElement",
+            "range": [
+                78,
+                117
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 0
+                },
+                "end": {
+                    "line": 13,
+                    "column": 8
+                }
+            },
+            "name": "style",
+            "rawName": "style",
+            "namespace": "http://www.w3.org/1999/xhtml",
+            "startTag": {
+                "type": "VStartTag",
+                "range": [
+                    78,
+                    85
+                ],
+                "loc": {
+                    "start": {
+                        "line": 9,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 9,
+                        "column": 7
+                    }
+                },
+                "selfClosing": false,
+                "attributes": []
+            },
+            "children": [
+                {
+                    "type": "VText",
+                    "range": [
+                        85,
+                        109
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 9,
+                            "column": 7
+                        },
+                        "end": {
+                            "line": 13,
+                            "column": 0
+                        }
+                    },
+                    "value": "\na {\n    color: pink;\n}\n"
+                }
+            ],
+            "endTag": {
+                "type": "VEndTag",
+                "range": [
+                    109,
+                    117
+                ],
+                "loc": {
+                    "start": {
+                        "line": 13,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 13,
+                        "column": 8
+                    }
+                }
+            },
+            "variables": []
+        }
+    ],
+    "tokens": [
+        {
+            "type": "HTMLTagOpen",
+            "range": [
+                0,
+                5
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 5
+                }
+            },
+            "value": "docs"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                5,
+                6
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 5
+                },
+                "end": {
+                    "line": 1,
+                    "column": 6
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                6,
+                11
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 6
+                },
+                "end": {
+                    "line": 2,
+                    "column": 4
+                }
+            },
+            "value": "\n    "
+        },
+        {
+            "type": "HTMLText",
+            "range": [
+                11,
+                14
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 7
+                }
+            },
+            "value": "doc"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                14,
+                15
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 7
+                },
+                "end": {
+                    "line": 3,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLEndTagOpen",
+            "range": [
+                15,
+                21
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 6
+                }
+            },
+            "value": "docs"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                21,
+                22
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 6
+                },
+                "end": {
+                    "line": 3,
+                    "column": 7
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                22,
+                23
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 7
+                },
+                "end": {
+                    "line": 4,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLTagOpen",
+            "range": [
+                23,
+                30
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 0
+                },
+                "end": {
+                    "line": 4,
+                    "column": 7
+                }
+            },
+            "value": "script"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                30,
+                31
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 7
+                },
+                "end": {
+                    "line": 4,
+                    "column": 8
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                31,
+                32
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 8
+                },
+                "end": {
+                    "line": 5,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                32,
+                38
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 0
+                },
+                "end": {
+                    "line": 5,
+                    "column": 6
+                }
+            },
+            "value": "export"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                38,
+                39
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 6
+                },
+                "end": {
+                    "line": 5,
+                    "column": 7
+                }
+            },
+            "value": " "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                39,
+                46
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 7
+                },
+                "end": {
+                    "line": 5,
+                    "column": 14
+                }
+            },
+            "value": "default"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                46,
+                47
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 14
+                },
+                "end": {
+                    "line": 5,
+                    "column": 15
+                }
+            },
+            "value": " "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                47,
+                48
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 15
+                },
+                "end": {
+                    "line": 5,
+                    "column": 16
+                }
+            },
+            "value": "{"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                48,
+                53
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 16
+                },
+                "end": {
+                    "line": 6,
+                    "column": 4
+                }
+            },
+            "value": "\n    "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                53,
+                58
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 4
+                },
+                "end": {
+                    "line": 6,
+                    "column": 9
+                }
+            },
+            "value": "name:"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                58,
+                59
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 9
+                },
+                "end": {
+                    "line": 6,
+                    "column": 10
+                }
+            },
+            "value": " "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                59,
+                65
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 10
+                },
+                "end": {
+                    "line": 6,
+                    "column": 16
+                }
+            },
+            "value": "'test'"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                65,
+                66
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 16
+                },
+                "end": {
+                    "line": 7,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                66,
+                67
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 0
+                },
+                "end": {
+                    "line": 7,
+                    "column": 1
+                }
+            },
+            "value": "}"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                67,
+                68
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 1
+                },
+                "end": {
+                    "line": 8,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLEndTagOpen",
+            "range": [
+                68,
+                76
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 0
+                },
+                "end": {
+                    "line": 8,
+                    "column": 8
+                }
+            },
+            "value": "script"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                76,
+                77
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 8
+                },
+                "end": {
+                    "line": 8,
+                    "column": 9
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                77,
+                78
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 9
+                },
+                "end": {
+                    "line": 9,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLTagOpen",
+            "range": [
+                78,
+                84
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 0
+                },
+                "end": {
+                    "line": 9,
+                    "column": 6
+                }
+            },
+            "value": "style"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                84,
+                85
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 6
+                },
+                "end": {
+                    "line": 9,
+                    "column": 7
+                }
+            },
+            "value": ""
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                85,
+                86
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 7
+                },
+                "end": {
+                    "line": 10,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                86,
+                87
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 0
+                },
+                "end": {
+                    "line": 10,
+                    "column": 1
+                }
+            },
+            "value": "a"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                87,
+                88
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 1
+                },
+                "end": {
+                    "line": 10,
+                    "column": 2
+                }
+            },
+            "value": " "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                88,
+                89
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 2
+                },
+                "end": {
+                    "line": 10,
+                    "column": 3
+                }
+            },
+            "value": "{"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                89,
+                94
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 3
+                },
+                "end": {
+                    "line": 11,
+                    "column": 4
+                }
+            },
+            "value": "\n    "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                94,
+                100
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 4
+                },
+                "end": {
+                    "line": 11,
+                    "column": 10
+                }
+            },
+            "value": "color:"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                100,
+                101
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 10
+                },
+                "end": {
+                    "line": 11,
+                    "column": 11
+                }
+            },
+            "value": " "
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                101,
+                106
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 11
+                },
+                "end": {
+                    "line": 11,
+                    "column": 16
+                }
+            },
+            "value": "pink;"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                106,
+                107
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 16
+                },
+                "end": {
+                    "line": 12,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLRawText",
+            "range": [
+                107,
+                108
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 0
+                },
+                "end": {
+                    "line": 12,
+                    "column": 1
+                }
+            },
+            "value": "}"
+        },
+        {
+            "type": "HTMLWhitespace",
+            "range": [
+                108,
+                109
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 1
+                },
+                "end": {
+                    "line": 13,
+                    "column": 0
+                }
+            },
+            "value": "\n"
+        },
+        {
+            "type": "HTMLEndTagOpen",
+            "range": [
+                109,
+                116
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 0
+                },
+                "end": {
+                    "line": 13,
+                    "column": 7
+                }
+            },
+            "value": "style"
+        },
+        {
+            "type": "HTMLTagClose",
+            "range": [
+                116,
+                117
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 7
+                },
+                "end": {
+                    "line": 13,
+                    "column": 8
+                }
+            },
+            "value": ""
+        }
+    ],
+    "comments": [],
+    "errors": []
+}

--- a/test/fixtures/document-fragment/template-tag-is-present/source.vue
+++ b/test/fixtures/document-fragment/template-tag-is-present/source.vue
@@ -1,0 +1,13 @@
+<docs>
+    doc
+</docs>
+<script>
+export default {
+    name: 'test'
+}
+</script>
+<style>
+a {
+    color: pink;
+}
+</style>


### PR DESCRIPTION
`VDocumentFragment` is required even if `<template>` does not exist, to implement `vue/component-tags-order`.
https://github.com/vuejs/eslint-plugin-vue/pull/763

`getDocumentFragment()` can get `VDocumentFragment` even if `<template>` does not exist.

