### PR TITLE
fix: hide warnings about memory leaks

### DIFF
--- a/src/parser-services.ts
+++ b/src/parser-services.ts
@@ -63,7 +63,9 @@ export function define(rootAST: ESLintProgram): ParserServices {
 
             // If this is the first time, initialize the intermediate event emitter.
             if (emitter == null) {
-                emitters.set(rootAST, (emitter = new EventEmitter()))
+                emitter = new EventEmitter()
+                emitter.setMaxListeners(0)
+                emitters.set(rootAST, emitter)
 
                 const programExitHandler = scriptVisitor["Program:exit"]
                 scriptVisitor["Program:exit"] = node => {


### PR DESCRIPTION
A warning was issued to set `setMaxListeners` from `EventEmitter`, and I fixed to hide the warning.

↓example
```
$ npm run lint

> ci-eslint@1.0.0 lint /Users/sawa-zen/develop/sandbox/ci-eslint
> eslint --ext .js,.vue --ignore-path .gitignore .

(node:92395) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 VElement listeners added. Use emitter.setMaxListeners() to increase limit
```