### PR TITLE
Use Coffeescript-compatible template expression wrapper

### DIFF
--- a/src/script/index.ts
+++ b/src/script/index.ts
@@ -364,7 +364,7 @@ function parseExpressionBody(
     parserOptions: any,
     allowEmpty = false,
 ): ExpressionParseResult<ESLintExpression> {
-    debug('[script] parse expression: "f(%s)"', code)
+    debug('[script] parse expression: "[%s]"', code)
 
     try {
         const ast = parseScriptFragment(

--- a/src/script/index.ts
+++ b/src/script/index.ts
@@ -364,11 +364,11 @@ function parseExpressionBody(
     parserOptions: any,
     allowEmpty = false,
 ): ExpressionParseResult<ESLintExpression> {
-    debug('[script] parse expression: "0(%s)"', code)
+    debug('[script] parse expression: "f(%s)"', code)
 
     try {
         const ast = parseScriptFragment(
-            `0(${code})`,
+            `f(${code})`,
             locationCalculator.getSubCalculatorAfter(-2),
             parserOptions,
         ).ast

--- a/src/script/index.ts
+++ b/src/script/index.ts
@@ -9,7 +9,7 @@ import sortedIndexBy from "lodash/sortedIndexBy"
 import {
     traverseNodes,
     ESLintArrayPattern,
-    ESLintCallExpression,
+    ESLintArrayExpression,
     ESLintExpression,
     ESLintExpressionStatement,
     ESLintExtendedProgram,
@@ -368,16 +368,16 @@ function parseExpressionBody(
 
     try {
         const ast = parseScriptFragment(
-            `f(${code})`,
-            locationCalculator.getSubCalculatorAfter(-2),
+            `[${code}]`,
+            locationCalculator.getSubCalculatorAfter(-1),
             parserOptions,
         ).ast
         const tokens = ast.tokens || []
         const comments = ast.comments || []
         const references = analyzeExternalReferences(ast, parserOptions)
         const statement = ast.body[0] as ESLintExpressionStatement
-        const callExpression = statement.expression as ESLintCallExpression
-        const expression = callExpression.arguments[0]
+        const arrayExpression = statement.expression as ESLintArrayExpression
+        const expression = arrayExpression.elements[0]
 
         if (!allowEmpty && !expression) {
             return throwEmptyError(locationCalculator, "an expression")
@@ -385,16 +385,15 @@ function parseExpressionBody(
         if (expression && expression.type === "SpreadElement") {
             return throwUnexpectedTokenError("...", expression)
         }
-        if (callExpression.arguments[1]) {
-            const node = callExpression.arguments[1]
+        if (arrayExpression.elements[1]) {
+            const node = arrayExpression.elements[1]
             return throwUnexpectedTokenError(
                 ",",
                 getCommaTokenBeforeNode(tokens, node) || node,
             )
         }
 
-        // Remove parens.
-        tokens.shift()
+        // Remove braces.
         tokens.shift()
         tokens.pop()
 

--- a/test/fixtures/ast/error-message-outside/ast.json
+++ b/test/fixtures/ast/error-message-outside/ast.json
@@ -1345,9 +1345,9 @@
             },
             {
                 "message": "Unexpected end of expression.",
-                "index": 76,
+                "index": 75,
                 "lineNumber": 4,
-                "column": 24
+                "column": 23
             },
             {
                 "message": "Unexpected end of expression.",


### PR DESCRIPTION
Hi,

We have just released Coffeescript v2.5.0 with AST support + [`eslint-plugin-coffee`](https://github.com/helixbass/eslint-plugin-coffee) ESLint custom parser + plugin

I got a [bug report](https://github.com/helixbass/eslint-plugin-coffee/issues/27) from someone trying to set up ESLint in a Vue + Coffeescript project

When I looked, the problem is that in `parseExpressionBody()` you are wrapping template expressions in `0(...)`, which [doesn't parse in Coffeescript](http://coffeescript.org/#try:0(b))

So this PR updates to use `[...]` wrapper instead of `0(...)`