### PR TITLE
feat: optionally use component tag as template root

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vue-eslint-parser",
+  "name": "@garage11/vue-eslint-parser",
   "version": "7.0.0",
   "description": "The ESLint custom parser for `.vue` files.",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garage11/vue-eslint-parser",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "The ESLint custom parser for `.vue` files.",
   "engines": {
     "node": ">=8.10"

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,10 @@ function isVueFile(code: string, options: any): boolean {
  * @returns `true` if the node is a `<template>` element.
  */
 function isTemplateElement(node: AST.VNode): node is AST.VElement {
-    return node.type === "VElement" && node.name === "template"
+    return (
+        node.type === "VElement" &&
+        ["template", "component"].includes(node.name)
+    )
 }
 
 /**


### PR DESCRIPTION
[Vuepack](https://github.com/garage11/vuepack) is a simple Vue template compiler, which separates compiled Vue templates and component JavaScript. This makes it easy to create a build flow around non-bundling approaches like Snowpack. It expects templates like [this](https://github.com/garage11/vuepack-demo/blob/master/src/components/header/header.vue); e.g. it doesn't require a <template> tag. I could strip the <template> tag during Vuepack's building, but it seems like an unnecessary polution of template code, if not using Vue's SFC. 

My naive first approach to let vue-eslint-parser lint these kind of vue-html files is to change the detected template root element and disable the `vue/valid-template-root` rule. Another option I considered was to pass the mode-of-operation along with eslint's parserOptions, but this seemed to be the fastest approach to get some initial feedback. Let me know if it needs more work.

