### PR TITLE
Upgrade "eslint-visitor-keys" and supports "ExportAllDeclaration.exported"

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "debug": "^4.1.1",
     "eslint-scope": "^5.0.0",
-    "eslint-visitor-keys": "^1.1.0",
+    "eslint-visitor-keys": "^1.2.0",
     "espree": "^6.2.1",
     "esquery": "^1.0.1",
     "lodash": "^4.17.15"


### PR DESCRIPTION
This PR upgrades "eslint-visitor-keys" so that the correct location of "ExportAllDeclaration.exported" can be calculated.

I tried to add a test case under `test/fixtures/ast`, but I need to add `sourceType: "module"` to the parser options. But, I did not add a test case because doing this would result in changes to over 100 files.