### PR TITLE
Add `delimiter` to `VForExpression`

### DIFF
--- a/docs/ast.md
+++ b/docs/ast.md
@@ -97,6 +97,7 @@ interface Reference {
 
 interface VForExpression <: Expression {
     type: "VForExpression"
+    delimiter: "in" | "of"
     left: [ Pattern ]
     right: Expression
 }

--- a/src/ast/nodes.ts
+++ b/src/ast/nodes.ts
@@ -668,6 +668,7 @@ export interface Reference {
 export interface VForExpression extends HasLocation, HasParent {
     type: "VForExpression"
     parent: VExpressionContainer
+    delimiter: "in" | "of"
     left: ESLintPattern[]
     right: ESLintExpression
 }

--- a/src/script/index.ts
+++ b/src/script/index.ts
@@ -751,6 +751,7 @@ export function parseVForExpression(
             range: [firstToken.range[0], lastToken.range[1]],
             loc: { start: firstToken.loc.start, end: lastToken.loc.end },
             parent: DUMMY_PARENT,
+            delimiter: ast.body[0].type === "ForInStatement" ? "in" : "of",
             left,
             right,
         }
@@ -763,7 +764,7 @@ export function parseVForExpression(
         }
         right.parent = expression
 
-        // Remvoe `for` `(` `let` `)` `;`.
+        // Remove `for` `(` `let` `)` `;`.
         tokens.shift()
         tokens.shift()
         tokens.shift()

--- a/test/fixtures/ast/hole-in-array/ast.json
+++ b/test/fixtures/ast/hole-in-array/ast.json
@@ -258,6 +258,7 @@
                                                     "column": 34
                                                 }
                                             },
+                                            "delimiter": "in",
                                             "left": [
                                                 {
                                                     "type": "Identifier",

--- a/test/fixtures/ast/v-for-directives-with-destructuring/ast.json
+++ b/test/fixtures/ast/v-for-directives-with-destructuring/ast.json
@@ -201,6 +201,7 @@
                                             "column": 34
                                         }
                                     },
+                                    "delimiter": "in",
                                     "left": [
                                         {
                                             "type": "ObjectPattern",
@@ -609,6 +610,7 @@
                                             "column": 35
                                         }
                                     },
+                                    "delimiter": "in",
                                     "left": [
                                         {
                                             "type": "ArrayPattern",
@@ -975,6 +977,7 @@
                                             "column": 29
                                         }
                                     },
+                                    "delimiter": "of",
                                     "left": [
                                         {
                                             "type": "ArrayPattern",
@@ -1297,6 +1300,7 @@
                                             "column": 40
                                         }
                                     },
+                                    "delimiter": "in",
                                     "left": [
                                         {
                                             "type": "ObjectPattern",

--- a/test/fixtures/ast/v-for-directives/ast.json
+++ b/test/fixtures/ast/v-for-directives/ast.json
@@ -201,6 +201,7 @@
                                             "column": 25
                                         }
                                     },
+                                    "delimiter": "in",
                                     "left": [
                                         {
                                             "type": "Identifier",
@@ -459,6 +460,7 @@
                                             "column": 33
                                         }
                                     },
+                                    "delimiter": "in",
                                     "left": [
                                         {
                                             "type": "Identifier",
@@ -803,6 +805,7 @@
                                             "column": 25
                                         }
                                     },
+                                    "delimiter": "of",
                                     "left": [
                                         {
                                             "type": "Identifier",
@@ -1061,6 +1064,7 @@
                                             "column": 33
                                         }
                                     },
+                                    "delimiter": "of",
                                     "left": [
                                         {
                                             "type": "Identifier",


### PR DESCRIPTION
~Needed for https://github.com/vuejs/eslint-plugin-vue/issues/1228 (probably :sweat_smile:).~

This would make `vue/v-for-delimiter-style` ESLint rule (https://github.com/vuejs/eslint-plugin-vue/issues/1228 / https://github.com/vuejs/eslint-plugin-vue/pull/1267) implementation easier.